### PR TITLE
Cathing NullReferenceExpetion inside InitAdapter

### DIFF
--- a/source/Cross.BluetoothLe/Platform/Windows/BluetoothLE.uwp.netcore.netf.cs
+++ b/source/Cross.BluetoothLe/Platform/Windows/BluetoothLE.uwp.netcore.netf.cs
@@ -65,16 +65,25 @@ namespace Cross.BluetoothLe
 
     private async Task InitAdapter()
     {
-      NativeAdapter = await BluetoothAdapter.GetDefaultAsync();
-
-      _radio = await NativeAdapter.GetRadioAsync();
-
-      if (_radio != null)
+      try
       {
-        _radio.StateChanged += OnRadioStateChanged;
-      }
 
-      State = GetInitialStateNative();
+        NativeAdapter = await BluetoothAdapter.GetDefaultAsync();
+
+        _radio = await NativeAdapter.GetRadioAsync();
+
+        if (_radio != null)
+        {
+          _radio.StateChanged += OnRadioStateChanged;
+        }
+
+        State = GetInitialStateNative();
+      }
+      catch(NullReferenceException)
+      {
+        NativeAdapter = null;
+        State = BluetoothState.Unknown;
+      }
     }
 
     private void OnRadioStateChanged(Radio sender, object args)


### PR DESCRIPTION
Was not able to catch NullReferenceException trhown inside async void InitializeNative when calling tryng to enumerate devices from a machine with a malfunctiong dongle